### PR TITLE
Modify killDelisted flag

### DIFF
--- a/bin/hipcheck
+++ b/bin/hipcheck
@@ -45,8 +45,8 @@ program
     "Disk location where to cache. Flag.")
   .option('-f, --delete-cache',
     "Delete cache (reset cached hosts). Flag.")
-  .option('-k, --kill-delisted',
-    "Remove delisted hosts to avoid excessive error responses from bad hosts. Flag.")
+  .option('-k, --kill-delisted <n>',
+    'Remove delisted hosts to avoid excessive error responses from bad hosts; integer parameter indicates the number of retries before killing the host. ', parseInt)
   .option('-e, --rollbar <s>',
     "Rollbar token for error tracking. Default: undefined");
 

--- a/lib/Heartbeat.js
+++ b/lib/Heartbeat.js
@@ -17,6 +17,8 @@ function Heartbeat (options) {
   var url = this.options.url;
   var method = this.options.method;
   this.niceUrl = method.toUpperCase()+' '+url;
+
+  this.failCount = 0;
 }
 
 util.inherits(Heartbeat, EventEmitter);
@@ -100,10 +102,12 @@ Heartbeat.prototype.onError = function (err) {
   if (err.known) e.known = err.known;
   e.type = 'heartbeat';
   this.emit('error', e, this);
+  this.failCount ++;
 };
 
 Heartbeat.prototype.onSuccess = function (code) {
   this.errorStreak = 0;
   this.log('success '+code);
   this.emit('success', this);
+  this.failCount = 0;
 };

--- a/lib/VhostChecker.js
+++ b/lib/VhostChecker.js
@@ -131,9 +131,14 @@ VhostChecker.prototype.handleLatestHosts = function (latestHosts) {
     self.createHeartbeatFor(host);
   });
 
-  if (this.options.killDelisted) {
+  // Kill delisted host if the number of failed retries exceed the given killDelisted parameter
+  var heartbeats = this.heartbeats;
+  var options = this.options;
+  if (options.killDelisted) {
     delistedHosts.forEach(function (host) {
-        self.removeHeartbeatFor(host);
+        if (heartbeats[host].failCount >= options.killDelisted) {
+            self.removeHeartbeatFor(host);
+        }
     });
   }
 


### PR DESCRIPTION
Modify killDelisted flag to include the max number of retries before killing delisted host.

Sample command line:
bin/hipcheck --redis redirect1-staging.crsinc.com:6380 --timeout 10 --interval 2 --hosts_interval 2 -k 5  http://www-staging.crsinc.com/nginx_status
